### PR TITLE
Revert "Add proper logging and --verbose mode"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 21.12b0
     hooks:
     - id: black
       language_version: python3

--- a/ideas/__main__.py
+++ b/ideas/__main__.py
@@ -5,16 +5,12 @@ If no source is given, ideas will start an interactive console.
 
 import argparse
 from importlib import import_module
-import logging
 import sys
 
 import ideas
 from ideas import console
 from ideas.session import config
 
-
-logger = logging.getLogger("ideas")
-logging.basicConfig(level=logging.WARNING)
 
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -25,13 +21,6 @@ parser.add_argument(
     "-v",
     "--version",
     help="Only displays the current version.",
-    action="store_true",
-)
-
-parser.add_argument(
-    "-V",
-    "--verbose",
-    help="Print debugging messages during runtime.",
     action="store_true",
 )
 
@@ -112,8 +101,6 @@ def main() -> None:
     if args.version:
         print(f"\nideas version {ideas.__version__}")
         return
-    elif not args.verbose:
-        logger.setLevel(logging.INFO)
 
     config.show_changes = bool(args.show_changes)
 

--- a/ideas/import_hook.py
+++ b/ideas/import_hook.py
@@ -5,11 +5,8 @@ This module contains the core functions required to create an import hook.
 """
 
 import ast
-import logging
 import os
 import sys
-from types import CodeType, ModuleType
-from typing import Callable, Dict, Sequence, Optional, Any
 
 from importlib.abc import Loader, MetaPathFinder
 from importlib.util import spec_from_file_location, decode_source
@@ -17,9 +14,6 @@ from importlib.util import spec_from_file_location, decode_source
 from . import console
 from .session import config
 from .utils import shorten_path, PYTHON, IDEAS, SITE_PACKAGES, print_source
-
-
-logger = logging.getLogger(__name__)
 
 
 def finder_inform(text):
@@ -193,18 +187,18 @@ class IdeasLoader(Loader):  # pylint: disable=R0902
 
         try:
             tree = ast.parse(source, self.filename)
-        except Exception:
-            logger.debug("Exception raised while parsing source.")
-            raise
+        except Exception as exc:
+            print("Exception raised while parsing source.")
+            raise exc
 
         if self.transform_ast is not None:
             tree = self.transform_ast(tree)
 
         try:
             code_object = compile(tree, self.filename, "exec")
-        except Exception:
-            logger.debug("Exception raised while compiling tree.")
-            raise
+        except Exception as exc:
+            print("Exception raised while compiling tree.")
+            raise exc
 
         if self.transform_bytecode is not None:
             code_object = self.transform_bytecode(code_object)
@@ -220,26 +214,26 @@ class IdeasLoader(Loader):  # pylint: disable=R0902
         else:
             try:
                 exec(code_object, module.__dict__)  # pylint: disable=W0122
-            except Exception:
-                logger.debug("Exception raised while executing code object.")
-                raise
+            except Exception as exc:
+                print("Exception raised while executing code object.")
+                raise exc
 
 
 def create_hook(
-    callback_params: Optional[Dict[str, Any]] = None,
-    create_module: Optional[Callable[..., ModuleType]] = None,
-    console_dict: Optional[Dict[str, Any]] = None,
-    exec_: Optional[Callable[..., None]] = None,
-    extensions: Optional[Sequence[str]] = None,
-    first: bool = True,
-    hook_name: Optional[str] = None,
-    ipython_ast_node_transformer: Optional[ast.NodeTransformer] = None,
-    module_class: Optional[type] = None,
-    source_init: Optional[str] = None,
-    transform_ast: Optional[ast.NodeTransformer] = None,
-    transform_bytecode: Optional[Callable[[CodeType], CodeType]] = None,
-    transform_source: Optional[Callable[[str], str]] = None,
-) -> IdeasMetaFinder:  # pylint: disable=R0913,R0914
+    callback_params=None,
+    create_module=None,
+    console_dict=None,
+    exec_=None,
+    extensions=None,
+    first=True,
+    hook_name=None,
+    ipython_ast_node_transformer=None,
+    module_class=None,
+    source_init=None,
+    transform_ast=None,
+    transform_bytecode=None,
+    transform_source=None,
+):  # pylint: disable=R0913,R0914
     """Function to facilitate the creation of an import hook.
 
     Each of the following parameter is optional; most of these are


### PR DESCRIPTION
Reverts aroberge/ideas#32

Adding logging breaks the console as typing "exit()" generates a traceback:
```
Traceback (most recent call last):
  File "C:\Users\Andre\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\Andre\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\Andre\github\ideas\ideas\__main__.py", line 141, in <module>
    main()
  File "C:\Users\Andre\github\ideas\ideas\__main__.py", line 138, in main
    console.start()
  File "C:\Users\Andre\github\ideas\ideas\console.py", line 200, in start
    console.interact(banner=banner)
  File "C:\Users\Andre\AppData\Local\Programs\Python\Python310\lib\code.py", line 232, in interact
    more = self.push(line)
  File "C:\Users\Andre\github\ideas\ideas\console.py", line 100, in push
    more = self.runsource(source, CONSOLE_NAME)
  File "C:\Users\Andre\github\ideas\ideas\console.py", line 171, in runsource
    self.runcode(code_obj)
  File "C:\Users\Andre\AppData\Local\Programs\Python\Python310\lib\code.py", line 90, in runcode
    exec(code, self.locals)
  File "Ideas Console", line -1, in <module>
  File "C:\Users\Andre\AppData\Local\Programs\Python\Python310\lib\_sitebuiltins.py", line 26, in __call__
    raise SystemExit(code)
SystemExit: None
```