### PR TITLE
Support CLI history with the readline module

### DIFF
--- a/ideas/console.py
+++ b/ideas/console.py
@@ -7,6 +7,7 @@ used with import hooks.
 
 import ast
 import platform
+import readline
 import os
 import sys
 import traceback
@@ -64,6 +65,8 @@ class IdeasConsole(InteractiveConsole):
             console_dict = {}
         if locals_ is not None:
             console_dict.update(**locals_)
+
+        readline.parse_and_bind('tab: complete')
 
         super().__init__(locals=console_dict)
         self.filename = CONSOLE_NAME


### PR DESCRIPTION
"Tab" binding is actually optional.

Much more enhanced setup [is possible](https://github.com/diofant/diofant/blob/dc76ed327fe4ec6bd8755049320c3bc9cb117568/diofant/__main__.py#L97-L108).  But I'm not sure where we should save the history file (or files?).